### PR TITLE
fix: empty query

### DIFF
--- a/src/pyfwapi/apiconnection.py
+++ b/src/pyfwapi/apiconnection.py
@@ -42,7 +42,7 @@ class APIConnection:
 
     async def ensure_token(self):
         """Ensure that the OAuth2 client has fetched a token."""
-        # AsyncOAuth2Clien locks to ensure no race conditions when fetching the token.
+        # AsyncOAuth2Client locks to ensure no race conditions when fetching the token.
         if not self.client.token:
             await self.client.fetch_token()  # type: ignore
 

--- a/src/pyfwapi/search/search_expression.py
+++ b/src/pyfwapi/search/search_expression.py
@@ -171,7 +171,7 @@ class SE:
         return self.AND(other)
 
     def __str__(self) -> str:
-        return str(self.data)
+        return str(self.data or "")  # prevent "None"
 
     def __repr__(self) -> str:
         return f"""SE(ast={repr(self.data)})"""

--- a/src/pyfwapi/tenant.py
+++ b/src/pyfwapi/tenant.py
@@ -104,7 +104,10 @@ class Tenant:
                 pyfwapiLog.error(f"Collection '{a}' cannot be searched")
                 raise CollectionNotSearchable("Collection '{a}' has no searchURL")
 
-            q = ";o=+?q=" + quote(str(query).strip())  # order by oldest modified
+            qval = quote(str(query).strip())
+            if qval != "":
+                qval = f"?q={qval}"
+            q = f";o=+{qval}"  # order by oldest modified
             query_url = search_base_url.replace(FOTOWARE_QUERY_PLACEHOLDER, q)
             async for asset in self.api.paginated(query_url, type=Asset):
                 yield asset
@@ -161,7 +164,7 @@ class UnstableTenant(Tenant):
     """This subclass of Tenant also provides access to undocumented APIs."""
 
     async def namespaces(self) -> t.AsyncGenerator[FieldNamespace, None]:
-        """Registered metadata namespaces."""
+        """Registered metadata namespaces. (Undocumented.)"""
         d = await self.api.GET("/fotoweb/api/config/metadata/namespaces")
         for namespace in d.json():
             yield namespace
@@ -169,7 +172,7 @@ class UnstableTenant(Tenant):
     async def known_fields(
         self,
     ) -> t.AsyncGenerator[KnownMetadataField, None]:
-        """Registered metadata fields."""
+        """Registered metadata fields. (Undocumented.)"""
         d = await self.api.GET("/fotoweb/api/config/metadata/fields/known")
         for field in d.json():
             yield field


### PR DESCRIPTION
If a SE was empty, the asset iterator would fail by searching on "None".